### PR TITLE
Update healthcheck endpoint to also report uptime.

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ module.exports = options => {
   };
 
   // shallow health check
-  app.get('/healthz/ping', (req, res) => res.sendStatus(200));
+  app.get('/healthz/ping', require('express-healthcheck')());
 
   if (!config || !config.routes || !config.routes.length) {
     throw new Error('Must be called with a list of routes');

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "connect-redis": "^3.1.0",
     "cookie-parser": "^1.4.1",
     "express": "^4.13.4",
+    "express-healthcheck": "^0.1.0",
     "express-partial-templates": "^0.2.0",
     "express-session": "^1.13.0",
     "helmet": "^2.3.0",


### PR DESCRIPTION
This middleware also gives us hook in the future to check other layers for a deeper healthcheck.