### PR TITLE
Make views and fields use defaults properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ HOF-bootstrap accepts the following options so a developer can customise element
 
 ### Options
 
-- `views`: Location of the base views relative to the root of your project. Defaults to 'views'. Set `views` to `false` if not present.
+- `views`: Location of the base views relative to the root of your project. Defaults to `__dirname + '/views'`.
+- `fields`: Location of the common fields relative to the root of your project. Defaults to `__dirname + '/fields'`.
+- `translations`: Location of the common translations relative to the root of your project. Defaults to `./translations`.
 - `middleware`: An optional array of middleware functions to add to the application middleware pipeline.
-- `fields`: Location of the common fields relative to the root of your project. Defaults to 'fields'. Set `fields` to `false` if not present.
-- `translations`: Location of the common translations relative to the root of your project. Defaults to 'translations'.
 - `baseController`: The base controller for all routes and steps. Defaults to [HOF-controllers.base](https://github.com/UKHomeOfficeForms/hof-controllers/blob/master/lib/base-controller.js).
 - `viewEngine`: Name of the express viewEngine. Defaults to 'html'.
 - `start`: Start the server listening when the bootstrap function is called. Defaults to `true`.
@@ -223,12 +223,28 @@ const myRoutes = [{
 [Read more about steps and fields](https://github.com/UKHomeOfficeForms/HOF/blob/master/documentation/index.md)
 
 #### Options
-- `name`: If provided, is used to locate views, fields and translations for a form journey.
+- `name`: Passed to the form Wizard.
 - `baseUrl`: Base url from which all steps are relative. Defaults to `/`. If provided will be used to locate views, fields and translations for a form journey.
-- `fields`: Location of the routes' fields, relative to the root of your project. Defaults to `fields`.
-- `views`: Location of the routes' views relative to the root of your project. Defaults to `views`.
+- `fields`: Location of the routes' fields, relative to the root of your project. Defaults to `__dirname + '/fields'`.
+- `views`: Location of the routes' views relative to the root of your project. Defaults to `__dirname + '/views'`.
 
-**NOTE**: `fields` defined in a `route` determine the name of the directory or path, relative to the root, where the `fields` module is located. `fields` defined in a step, are a list of the name of each field you want to use in the step.
+**NOTE**: The `fields` defined in a `route` is the path to the folder, relative to the root, where the `fields` are is located.
+The `fields` defined in a `step`, are a list of the name of each field you want to use in the step.
+
+For example:
+```
+[{
+  fields: '../../fields',
+  steps: {
+    '/one': {
+      fields: [
+        'name_of_field_one',
+        'name_of_field_two'
+      ]
+    }
+  }
+}];
+```
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -156,8 +156,15 @@ HOF-bootstrap accepts the following options so a developer can customise element
 
 ### Options
 
-- `views`: Location of the base views relative to the root of your project. Defaults to `__dirname + '/views'`.
+- `views`: Location of the base views relative to the root of your project.
+  - Will not error if it can't find any views in the root of your project.
+  - Looks for views - optionally set in your [route options](#route-options).
+  - Always loads views from [hof-template-partials.views](https://github.com/UKHomeOfficeForms/hof-template-partials/tree/master/views).
+  - Views extend like so, where route-views are the most specific: `hot-template-partials -> your-common-views -> your-route-views`
+
 - `fields`: Location of the common fields relative to the root of your project. Defaults to `__dirname + '/fields'`.
+  - Will not error if it can't find any views in the root of your project.
+
 - `translations`: Location of the common translations relative to the root of your project. Defaults to `./translations`.
 - `middleware`: An optional array of middleware functions to add to the application middleware pipeline.
 - `baseController`: The base controller for all routes and steps. Defaults to [HOF-controllers.base](https://github.com/UKHomeOfficeForms/hof-controllers/blob/master/lib/base-controller.js).
@@ -222,11 +229,11 @@ const myRoutes = [{
 ```
 [Read more about steps and fields](https://github.com/UKHomeOfficeForms/HOF/blob/master/documentation/index.md)
 
-#### Options
+#### Route Options
 - `name`: Passed to the form Wizard.
 - `baseUrl`: Base url from which all steps are relative. Defaults to `/`. If provided will be used to locate views, fields and translations for a form journey.
-- `fields`: Location of the routes' fields, relative to the root of your project. Defaults to `__dirname + '/fields'`.
-- `views`: Location of the routes' views relative to the root of your project. Defaults to `__dirname + '/views'`.
+- `fields`: Location of the routes' fields, relative to the root of your project. Will take precedence over fields specified at the base level.
+- `views`: Location of the routes' views relative to the root of your project. Will take precedence over views specified at the base level and from [hof-template-partials.views](https://github.com/UKHomeOfficeForms/hof-template-partials/tree/master/views).
 
 **NOTE**: The `fields` defined in a `route` is the path to the folder, relative to the root, where the `fields` are is located.
 The `fields` defined in a `step`, are a list of the name of each field you want to use in the step.

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -10,8 +10,6 @@ const caller = process.env.NODE_ENV === 'test' ? testPath : realPath;
 
 const defaults = {
   translations: 'translations',
-  views: 'views',
-  fields: 'fields',
   caller: caller,
   start: true,
   getCookies: true,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+module.exports = class Helpers {
+
+  static getPaths(config) {
+    return {
+      fields: {
+        base: config.fields && path.resolve(config.caller, config.fields),
+        route: config.route.fields && path.resolve(config.caller, config.route.fields)
+      },
+      views: {
+        base: config.views && path.resolve(config.caller, config.views),
+        route: config.route.views && path.resolve(config.caller, config.route.views)
+      },
+      translations: path.resolve(config.caller, config.route.translations || config.translations)
+    };
+  }
+
+  static getFields(pathFields) {
+    let routeFields;
+    let fields;
+
+    if (pathFields.base) {
+      try {
+        fields = require(pathFields.base);
+      } catch (err) {
+        throw new Error(`Cannot find fields at ${pathFields.base}`);
+      }
+    }
+
+    if (pathFields.route) {
+      try {
+        routeFields = require(pathFields.route);
+      } catch (err) {
+        throw new Error(`Cannot find route fields at ${pathFields.route}`);
+      }
+    }
+
+    return Object.assign({}, fields, routeFields);
+  }
+
+  static getViews(pathViews) {
+    let views = [];
+
+    if (pathViews.base) {
+      try {
+        fs.accessSync(pathViews.base);
+        views.unshift(pathViews.base);
+      } catch (err) {
+        throw new Error(`Cannot find views at ${pathViews.base}`);
+      }
+    }
+
+    if (pathViews.route) {
+      try {
+        fs.accessSync(pathViews.route);
+        views.unshift(pathViews.route);
+      } catch (err) {
+        throw new Error(`Cannot find route views at ${pathViews.route}`);
+      }
+    }
+
+    return views;
+  }
+
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -39,6 +39,10 @@ module.exports = class Helpers {
       }
     }
 
+    if (!fields && !routeFields) {
+      throw new Error('Set base fields or route fields or both');
+    }
+
     return Object.assign({}, fields, routeFields);
   }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,63 +1,28 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
 const express = require('express');
 const wizard = require('hof-form-wizard');
 const mixins = require('hof-template-mixins');
 const deepTranslate = require('hof-middleware').deepTranslate;
 const i18nFuture = require('i18n-future');
 const expressPartialTemplates = require('express-partial-templates');
-
-const getPaths = (appPath, config) => ({
-  fields: config.fields ? path.resolve(config.caller, config.fields) : config.fields,
-  routeFields: path.resolve(config.caller, config.route.fields || `${appPath}/fields`),
-  templates: path.resolve(config.caller, config.route.views || `${appPath}/views`),
-  translations: path.resolve(config.caller, config.route.translations || `${appPath}/translations`)
-});
-
-const getFields = paths => {
-  let routeFields;
-  let fields;
-
-  try {
-    if (paths.fields) {
-      fields = require(paths.fields);
-    }
-  } catch (err) {
-    throw new Error(`Cannot find fields at ${paths.fields}`);
-  }
-  try {
-    routeFields = require(paths.routeFields);
-  } catch (err) {
-    throw new Error(`Cannot find route fields at ${paths.routeFields}`);
-  }
-  return Object.assign({}, fields, routeFields);
-};
+const helpers = require('./helpers');
 
 module.exports = (config) => {
 
   const app = express();
-
   const baseUrl = config.route.baseUrl || '/';
   const name = config.route.name || baseUrl.replace('/', '');
-  const appPath = name ? `apps/${name}` : '.';
-  const paths = getPaths(appPath, config);
-  const fields = getFields(paths);
-
-  try {
-    fs.accessSync(paths.templates, fs.F_OK);
-  } catch (err) {
-    throw new Error(`Cannot find route views at ${paths.templates}`);
-  }
-
+  const paths = helpers.getPaths(config);
+  const fields = helpers.getFields(paths.fields);
+  const views = helpers.getViews(paths.views);
   const i18n = i18nFuture({
     path: paths.translations + '/__lng__/__ns__.json'
   });
 
   app.set('x-powered-by', false);
   app.set('view engine', config.viewEngine);
-  app.set('views', [paths.templates].concat(config.sharedViews));
+  app.set('views', views.concat(config.sharedViews));
 
   app.use(expressPartialTemplates(app));
 

--- a/test/fields/index.js
+++ b/test/fields/index.js
@@ -1,3 +1,5 @@
 'use strict';
 
-module.exports = {};
+module.exports = {
+  foo: {}
+};

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -39,7 +39,15 @@ describe('bootstrap()', () => {
     })).should.Throw('Each route must define a set of one or more steps')
   );
 
-  it('requires the path to fields argument to be valid', () =>
+  it('uses defaults when no fields option is specified', () =>
+    (() => bootstrap({
+      routes: [{
+        steps: {}
+      }]
+    })).should.not.Throw()
+  );
+
+  it('fields option must be valid when specified', () =>
     (() => bootstrap({
       fields: 'not_a_valid_path',
       routes: [{
@@ -48,9 +56,8 @@ describe('bootstrap()', () => {
     })).should.Throw('Cannot find fields at ' + path.resolve(__dirname, '../../test/not_a_valid_path'))
   );
 
-  it('requires the path to the route fields argument to be valid', () =>
+  it('route fields option must be valid when specified', () =>
     (() => bootstrap({
-      fields: '',
       routes: [{
         steps: {},
         fields: 'not_a_valid_path'
@@ -58,42 +65,30 @@ describe('bootstrap()', () => {
     })).should.Throw('Cannot find route fields at ' + path.resolve(__dirname, '../../test/not_a_valid_path'))
   );
 
-  it('requires the path to the views argument to be valid', () =>
+  it('uses defaults when no views option is specified', () =>
     (() => bootstrap({
-      views: 'not_a_valid_path',
       routes: [{
         steps: {}
       }]
-    })).should.Throw('Cannot find views at ' + path.resolve(__dirname, '../../test/not_a_valid_path'))
-  );
-
-  it('requires the path to the route views argument to be valid', () =>
-    (() => bootstrap({
-      routes: [{
-        steps: {},
-        views: 'not_a_valid_path',
-      }]
-    })).should.Throw('Cannot find route views at ' + path.resolve(__dirname, '../../test/not_a_valid_path'))
-  );
-
-  it('uses the route fields as the path', () =>
-    (() => bootstrap({
-      routes: [{
-        views: path.resolve(__dirname, '../apps/app_1/views'),
-        steps: {},
-        fields: 'fields'
-      }]
     })).should.not.Throw()
   );
 
-  it('uses the name to find a path to the fields', () =>
+  it('views option must be valid when specified', () =>
     (() => bootstrap({
+      views: 'invalid_path',
       routes: [{
-        views: path.resolve(__dirname, '../apps/app_1/views'),
-        name: 'app_1',
         steps: {}
       }]
-    })).should.not.Throw()
+    })).should.Throw('Cannot find views at ' + path.resolve(__dirname, '../../test/invalid_path'))
+  );
+
+  it('route views option must be valid when specified', () =>
+    (() => bootstrap({
+      routes: [{
+        views: 'invalid_path',
+        steps: {}
+      }]
+    })).should.Throw('Cannot find route views at ' + path.resolve(__dirname, '../../test/invalid_path'))
   );
 
   describe('with valid routes and steps', () => {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -39,12 +39,30 @@ describe('bootstrap()', () => {
     })).should.Throw('Each route must define a set of one or more steps')
   );
 
-  it('uses defaults when no fields option is specified', () =>
+  it('a base fields option must be specified if no route fields option is defined', () =>
     (() => bootstrap({
+      fields: 'fields',
       routes: [{
         steps: {}
       }]
     })).should.not.Throw()
+  );
+
+  it('a route fields option must be specified if no base fields option is defined', () =>
+    (() => bootstrap({
+      routes: [{
+        fields: 'apps/app_1/fields',
+        steps: {}
+      }]
+    })).should.not.Throw()
+  );
+
+  it('one of base fields or route fields must be specified as an option', () =>
+    (() => bootstrap({
+      routes: [{
+        steps: {}
+      }]
+    })).should.Throw('Set base fields or route fields or both')
   );
 
   it('fields option must be valid when specified', () =>
@@ -67,6 +85,7 @@ describe('bootstrap()', () => {
 
   it('uses defaults when no views option is specified', () =>
     (() => bootstrap({
+      fields: 'fields',
       routes: [{
         steps: {}
       }]
@@ -75,6 +94,7 @@ describe('bootstrap()', () => {
 
   it('views option must be valid when specified', () =>
     (() => bootstrap({
+      fields: 'fields',
       views: 'invalid_path',
       routes: [{
         steps: {}
@@ -84,6 +104,7 @@ describe('bootstrap()', () => {
 
   it('route views option must be valid when specified', () =>
     (() => bootstrap({
+      fields: 'fields',
       routes: [{
         views: 'invalid_path',
         steps: {}
@@ -95,6 +116,7 @@ describe('bootstrap()', () => {
 
     it('returns the bootstrap interface object', () =>
       bootstrap({
+        fields: 'fields',
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
           steps: {
@@ -106,6 +128,7 @@ describe('bootstrap()', () => {
 
     it('starts the service and responds successfully', () => {
       const bs = bootstrap({
+        fields: 'fields',
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
           steps: {
@@ -121,6 +144,7 @@ describe('bootstrap()', () => {
 
     it('accepts multiple routes', () => {
       const bs = bootstrap({
+        fields: 'fields',
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
           steps: {
@@ -147,6 +171,7 @@ describe('bootstrap()', () => {
 
     it('serves the correct view on request', () => {
       const bs = bootstrap({
+        fields: 'fields',
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
           steps: {
@@ -175,6 +200,7 @@ describe('bootstrap()', () => {
 
     it('looks up a view from the route directory', () => {
       const bs = bootstrap({
+        fields: 'fields',
         views: path.resolve(__dirname, '../apps/common/views'),
         routes: [{
           views: path.resolve(__dirname, '../apps/app_2/views'),
@@ -192,6 +218,7 @@ describe('bootstrap()', () => {
 
     it('falls back to common views if view not found in route views', () => {
       const bs = bootstrap({
+        fields: 'fields',
         views: path.resolve(__dirname, '../apps/common/views'),
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
@@ -209,6 +236,7 @@ describe('bootstrap()', () => {
 
     it('looks up from hof-template-partials if not found in any supplied views dir', () => {
       const bs = bootstrap({
+        fields: 'fields',
         views: path.resolve(__dirname, '../apps/common/views'),
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
@@ -226,6 +254,7 @@ describe('bootstrap()', () => {
 
     it('serves a view on request to an optional baseUrl', () => {
       const bs = bootstrap({
+        fields: 'fields',
         routes: [{
           baseUrl: '/app_1',
           views: path.resolve(__dirname, '../apps/app_1/views'),
@@ -243,6 +272,7 @@ describe('bootstrap()', () => {
 
     it('serves a view on request to an optional param', () => {
       const bs = bootstrap({
+        fields: 'fields',
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
           params: '/:action?',
@@ -260,6 +290,7 @@ describe('bootstrap()', () => {
 
     it('can instantiate a custom base controller for the app', () => {
       const bs = bootstrap({
+        fields: 'fields',
         baseController: CustomBaseController,
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
@@ -278,6 +309,7 @@ describe('bootstrap()', () => {
 
     it('does not start the service if start is false', () => {
       const bs = bootstrap({
+        fields: 'fields',
         start: false,
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
@@ -292,6 +324,7 @@ describe('bootstrap()', () => {
 
     it('starts the service when start is called', () => {
       const bs = bootstrap({
+        fields: 'fields',
         start: false,
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
@@ -312,6 +345,7 @@ describe('bootstrap()', () => {
 
     it('merges start options with the bootstrap config', () => {
       const bs = bootstrap({
+        fields: 'fields',
         start: false,
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
@@ -335,6 +369,7 @@ describe('bootstrap()', () => {
 
     it('stops the service when stop is called', done => {
       const bs = bootstrap({
+        fields: 'fields',
         start: false,
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
@@ -359,6 +394,7 @@ describe('bootstrap()', () => {
 
     it('serves static resources from /public', () => {
       const bs = bootstrap({
+        fields: 'fields',
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
           steps: {
@@ -374,6 +410,7 @@ describe('bootstrap()', () => {
 
     it('returns a 404 if the resource does not exist', () => {
       const bs = bootstrap({
+        fields: 'fields',
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
           steps: {
@@ -389,6 +426,7 @@ describe('bootstrap()', () => {
 
     it('returns a 200 for successful shallow health check', () => {
       const bs = bootstrap({
+        fields: 'fields',
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
           steps: {}
@@ -402,6 +440,7 @@ describe('bootstrap()', () => {
 
     it('can instantiate a custom controller for the route', () => {
       const bs = bootstrap({
+        fields: 'fields',
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),
           steps: {
@@ -421,6 +460,7 @@ describe('bootstrap()', () => {
 
     it('can pass the app config to a custom controller', () => {
       const bs = bootstrap({
+        fields: 'fields',
         appConfig: appConfig,
         routes: [{
           views: path.resolve(__dirname, '../apps/app_1/views'),


### PR DESCRIPTION
- don't need to add false to base level fields and views options
- uses default fields and views paths as last resort.
- does not throw if the default paths exist
- move getPaths, getViews, and getFields into helper class as statics
- update readme

EDIT:
- remove default fields and views values from defaults.js
- throw if no fields specified

Resolves #52 and #68 