### PR TITLE
Pass the apps' config through to controller via bootstrap

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -79,6 +79,10 @@ module.exports = (config) => {
     wizardConfig.params = config.route.params;
   }
 
+  if (config.appConfig) {
+    wizardConfig.appConfig = config.appConfig;
+  }
+
   app.use(wizard(config.route.steps, fields, wizardConfig));
 
   return app;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "express-session": "^1.13.0",
     "helmet": "^2.3.0",
     "hof-controllers": "^4.0.1",
-    "hof-form-wizard": "^1.0.2",
+    "hof-form-wizard": "^1.1.0",
     "hof-govuk-template": "^1.0.0",
     "hof-middleware": "^1.0.0",
     "hof-template-mixins": "^2.0.0",


### PR DESCRIPTION
- fix tests for controllers to guarantee they are being correctly set
- set appConfig on the wizard settings
- update to latest wizard (v1.1.0) so appConfig is passed to controller

This is so we can set the option `appConfig` on the bootstrap config;

```
bootstrap({
  appConfig: require('./config/js'),
  ...
});
```

A previous update to `hof-form-wizard` means that the `appConfig` will be set on the `options` that are passed to each controller new'd up in the wizard.

The upshot is we can acesss the apps' config from inside a controller so no need to set specific config objects on a step, such as;
```
confirm: {
   emailConfig: require('../../config').email,
  ...
}
```