### PR TITLE
amend case-sensitive typo in npm badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HOF (Home Office Forms) Bootstrap [![Build Status](https://travis-ci.org/UKHomeOfficeForms/hof-bootstrap.svg?branch=master)](https://travis-ci.org/UKHomeOfficeForms/hof-bootstrap) [![npm version](https://badge.fury.io/js/hof-bootstrap.svg)](https://badge.fury.io/js/HOF-bootstrap)
+# HOF (Home Office Forms) Bootstrap [![Build Status](https://travis-ci.org/UKHomeOfficeForms/hof-bootstrap.svg?branch=master)](https://travis-ci.org/UKHomeOfficeForms/hof-bootstrap) [![npm version](https://badge.fury.io/js/hof-bootstrap.svg)](https://badge.fury.io/js/hof-bootstrap)
 
 HOF-bootstrap is a wrapper function for HOF. It takes the hard work out of setting up your HOF service by encapsulating much of the boilerplate code in a single function. The bootstrap function takes many custom settings and options, but essentially maps your steps to Express routes and (optionally) starts the Express server.
 


### PR DESCRIPTION
now badge links to npm page