### PR TITLE
bugfix - fix broken paths to views and translations

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,28 +3,35 @@
 const fs = require('fs');
 const path = require('path');
 
-module.exports = class Helpers {
-
-  static getRouteFields(config) {
-    let routeFields = config.route.fields && path.resolve(config.caller, config.route.fields);
-    if (!routeFields) {
-      routeFields = config.route.name && path.resolve(config.caller, `apps/${config.route.name}/fields.js`);
-    }
-    return routeFields;
+const getPath = (config, part) => {
+  let result = config.route[part] && path.resolve(config.caller, config.route[part]);
+  if (!result) {
+    result = config.route.name && path.resolve(config.caller, `apps/${config.route.name}/${part}`);
   }
+  return result;
+};
 
+module.exports = class Helpers {
   static getPaths(config) {
     return {
       fields: {
         base: config.fields && path.resolve(config.caller, config.fields),
-        route: this.getRouteFields(config)
+        route: getPath(config, 'fields')
       },
-      views: {
-        base: config.views && path.resolve(config.caller, config.views),
-        route: config.route.views && path.resolve(config.caller, config.route.views)
-      },
-      translations: path.resolve(config.caller, config.route.translations || config.translations)
+      views: getPath(config, 'views'),
+      translations: getPath(config, 'translations')
     };
+  }
+
+  static getViews(views) {
+    if (views) {
+      try {
+        fs.accessSync(views);
+      } catch (err) {
+        throw new Error(`Cannot find route views at ${views}`);
+      }
+    }
+    return views;
   }
 
   static getFields(pathFields) {
@@ -52,29 +59,4 @@ module.exports = class Helpers {
 
     return Object.assign({}, fields, routeFields);
   }
-
-  static getViews(pathViews) {
-    let views = [];
-
-    if (pathViews.base) {
-      try {
-        fs.accessSync(pathViews.base);
-        views.unshift(pathViews.base);
-      } catch (err) {
-        throw new Error(`Cannot find views at ${pathViews.base}`);
-      }
-    }
-
-    if (pathViews.route) {
-      try {
-        fs.accessSync(pathViews.route);
-        views.unshift(pathViews.route);
-      } catch (err) {
-        throw new Error(`Cannot find route views at ${pathViews.route}`);
-      }
-    }
-
-    return views;
-  }
-
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -8,21 +8,24 @@ const i18nFuture = require('i18n-future');
 const expressPartialTemplates = require('express-partial-templates');
 const helpers = require('./helpers');
 
-module.exports = (config) => {
+module.exports = config => {
 
   const app = express();
   const baseUrl = config.route.baseUrl || '/';
   const name = config.route.name || baseUrl.replace('/', '');
   const paths = helpers.getPaths(config);
   const fields = helpers.getFields(paths.fields);
-  const views = helpers.getViews(paths.views);
   const i18n = i18nFuture({
     path: paths.translations + '/__lng__/__ns__.json'
   });
+  const routeViews = helpers.getViews(paths.views);
+  const sharedViews = config.sharedViews;
+
+  const views = routeViews ? [routeViews].concat(sharedViews) : sharedViews;
 
   app.set('x-powered-by', false);
   app.set('view engine', config.viewEngine);
-  app.set('views', views.concat(config.sharedViews));
+  app.set('views', views);
 
   app.use(expressPartialTemplates(app));
 


### PR DESCRIPTION
Since bootstrap v7 there have been a number of issues around implied paths. Previously it was assumed that `./views`, `./translations` and `./fields` would be relative to the path of the route. The previous change removed this and required them to be explicitly set. This commit allows them to be explicitly set, but if not it will attempt to locate them in the route directory as before. This actually removes the need for the previous major bump

* updated to use name if fields translations and views are not explicitly set
* removed duplicate shared views path