### PR TITLE
Fix bug with middleware mounting

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ module.exports = options => {
   const bootstrap = {
 
     use() {
-      router.use.apply(router, arguments);
+      userMiddleware.use.apply(userMiddleware, arguments);
       return bootstrap;
     },
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -481,4 +481,29 @@ describe('bootstrap()', () => {
 
   });
 
+  describe('with user defined middleware', () => {
+    it('can mount user defined middleware with `use`', () => {
+      const bs = bootstrap({
+        start: false,
+        fields: 'fields',
+        routes: [{
+          views: path.resolve(__dirname, '../apps/app_1/views'),
+          steps: {
+            '/one': {}
+          }
+        }]
+      });
+      bs.use((req, res) => {
+        res.json({respondedFromMiddleware: true});
+      });
+      bs.start();
+      return request(bs.server)
+        .get('/one')
+        .set('Cookie', ['myCookie=1234'])
+        .expect((response) =>
+          response.body.respondedFromMiddleware.should.equal(true)
+        );
+    });
+  });
+
 });


### PR DESCRIPTION
Variable name in `bootstrap.use` method was incorrect. Should have been `userMiddleware` and not `router`. This caused an error to be thrown when mounting middleware.

Fix and add a test to prevent regression.