### PR TITLE
Add basic Content Security Policy (CSP) middleware

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,0 @@
-{
-  "preset": "google",
-  "maximumLineLength": 120,
-  "excludeFiles": ["node_modules/**", "coverage/**", "test/public/**"]
-}

--- a/index.js
+++ b/index.js
@@ -49,6 +49,18 @@ module.exports = options => {
 
   app.use(helmet());
 
+  /* eslint-disable quotes */
+  app.use(helmet.contentSecurityPolicy({
+    directives: {
+      defaultSrc: ["'none'"],
+      styleSrc: ["'self'"],
+      imgSrc: ["'self'"],
+      fontSrc: ["'self'", "data:"],
+      scriptSrc: ["'self'", "'unsafe-inline'"]
+    }
+  }));
+  /* eslint-enable quotes */
+
   let config = getConfig(options);
 
   const i18n = i18nFuture({

--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
     "url": "https://github.com/UKHomeOffice/hof-bootstrap/issues"
   },
   "scripts": {
-    "test": "npm run unit && npm run style && npm run lint",
+    "test": "npm run unit && npm run lint",
     "unit": "NODE_ENV=test istanbul cover _mocha",
-    "style": "jscs index.js **/*.js test --config=./.jscsrc",
     "lint": "eslint .",
     "snyk": "snyk test",
     "snyk:dev": "snyk test --dev",
@@ -53,7 +52,6 @@
     "debug": "^2.2.0",
     "eslint-config-homeoffice": "^2.0.0",
     "istanbul": "^0.4.3",
-    "jscs": "^3.0.3",
     "mocha": "^2.4.5",
     "pre-commit": "^1.1.3",
     "sinomocha": "^0.2.4",


### PR DESCRIPTION
- CSP middlware defines a whitelist of origins assets can be loaded from.
- The script directive includes `"'unsafe-inline'"` due to the inline scripts
  inherited from govuk_templates (https://github.com/alphagov/govuk_template/issues/258).

- Remove jscs because it dupes eslint

Resolves: https://github.com/UKHomeOfficeForms/hof-bootstrap/issues/105