### PR TITLE
Throw error if session.secret is not set in production

### DIFF
--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -9,6 +9,10 @@ module.exports = (app, config) => {
 
   const logger = config.logger || console;
 
+  if (config.env === 'production' && config.session.secret === 'changethis') {
+    throw new Error('Session secret must be set to a unique random string for production environments');
+  }
+
   app.use(cookieParser(config.session.secret, {
     path: '/',
     httpOnly: true,


### PR DESCRIPTION
This provides some bullet-proof socks for people accidentally starting insecure apps in production environments.