### PR TITLE
Remove environment variable based root directory detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ HOF-bootstrap accepts the following options so a developer can customise element
 
 ### Options
 
+- `root`: The path to the project root directory.
+  - App paths will be relative to this directory.
+  - Defaults to the current working directory.
 - `views`: Location of the common views relative to the root of your project.
   - Will not error if it can't find any views in the root of your project.
   - Looks for views - optionally set in your [route options](#route-options).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ HOF-bootstrap is a wrapper function for HOF. It takes the hard work out of setti
   - [server](#server)
 - [Custom configuration](#custom-configuration)
   - [Options](#options)
+  - [Global configuration](#global-configuration)
   - [Environment variables](#environment-variables)
 - [Routes](#routes)
 - [Resources](#resources)
@@ -171,7 +172,8 @@ HOF-bootstrap accepts the following options so a developer can customise element
 - `middleware`: An optional array of middleware functions to add to the application middleware pipeline.
 - `baseController`: The base controller for all routes and steps. Defaults to [HOF-controllers.base](https://github.com/UKHomeOfficeForms/hof-controllers/blob/master/lib/base-controller.js).
 - `appConfig`: Allows you to attach a configuration object to each controllers' options argument. Useful if you need to access properties of your applications config settings in other parts of your code base, e.g:
-```
+
+```javascript
 ...
 constructor(options) {
   this.emailSettings = options.appConfig.emailSettings;
@@ -194,6 +196,16 @@ constructor(options) {
 - `session.ttl`: The session timeout in milliseconds. Defaults to `1800` (ms).
 - `session.secret`: The session secret. Set this to something unique.
 - `session.name`: The session name. Set this to something unique.
+
+### Global configuration
+
+Any of the configuration parameters can be set globally for all bootstrap instances by calling `bootstrap.configure`. This is mostly relevant for running unit tests which will create a large number of bootstrap instances.
+
+```javascript
+const bootstrap = require('hof-bootstrap');
+// set the project root to a custom location for all bootstrap instances
+boostrap.configure('root', path.resolve(__dirname, '..'));
+```
 
 ### Environent variables
 

--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ function bootstrap(options) {
 bootstrap.configure = function configure(key, val) {
   if (arguments.length === 2 && typeof key === 'string') {
     customConfig[key] = val;
-  } else {
+  } else if (typeof key === 'object') {
     Object.assign(customConfig, key);
   }
 };

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,21 +1,14 @@
 'use strict';
-
-const controllers = require('hof-controllers');
-const path = require('path');
-
-const testPath = path.resolve(__dirname, '../test/');
-const realPath = path.dirname(module.parent.parent.filename);
 /* eslint no-process-env: "off" */
-const caller = process.env.NODE_ENV === 'test' ? testPath : realPath;
 
 const defaults = {
+  root: process.cwd(),
   translations: 'translations',
-  caller: caller,
   start: true,
   getCookies: true,
   getTerms: true,
   viewEngine: 'html',
-  baseController: controllers.base,
+  baseController: require('hof-controllers').base,
   protocol: process.env.PROTOCOL || 'http',
   host: process.env.HOST || '0.0.0.0',
   port: process.env.PORT || '8080',

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,9 +4,9 @@ const fs = require('fs');
 const path = require('path');
 
 const getPath = (config, part) => {
-  let result = config.route[part] && path.resolve(config.caller, config.route[part]);
+  let result = config.route[part] && path.resolve(config.root, config.route[part]);
   if (!result) {
-    result = config.route.name && path.resolve(config.caller, `apps/${config.route.name}/${part}`);
+    result = config.route.name && path.resolve(config.root, `apps/${config.route.name}/${part}`);
   }
   return result;
 };
@@ -15,7 +15,7 @@ module.exports = class Helpers {
   static getPaths(config) {
     return {
       fields: {
-        base: config.fields && path.resolve(config.caller, config.fields),
+        base: config.fields && path.resolve(config.root, config.fields),
         route: getPath(config, 'fields')
       },
       views: getPath(config, 'views'),

--- a/lib/serve-static.js
+++ b/lib/serve-static.js
@@ -10,7 +10,7 @@ module.exports = (app, config) => {
     config.env === 'test' ||
     config.env === 'ci'
   ) {
-    app.use('/public', express.static(path.resolve(config.caller, 'public')));
+    app.use('/public', express.static(path.resolve(config.root, 'public')));
   }
 
   return app;

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -25,7 +25,7 @@ module.exports = (app, config) => {
   app.enable('view cache');
 
   if (config.views) {
-    const customViewPath = path.resolve(config.caller, config.views);
+    const customViewPath = path.resolve(config.root, config.views);
     try {
       fs.accessSync(customViewPath, fs.F_OK);
     } catch (err) {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "test": "npm run unit && npm run lint",
     "unit": "NODE_ENV=test istanbul cover _mocha",
+    "unit:nocov": "NODE_ENV=test mocha",
     "lint": "eslint .",
     "snyk": "snyk test",
     "snyk:dev": "snyk test --dev",

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -29,6 +29,10 @@ class CustomStepController extends CustomBaseController {
 
 describe('bootstrap()', () => {
 
+  before(() => {
+    bootstrap.configure('root', path.resolve(__dirname, '..'));
+  });
+
   it('must be given a list of routes', () =>
     (() => bootstrap()).should.Throw('Must be called with a list of routes')
   );


### PR DESCRIPTION
Having the project root directory be dependent on the NODE_ENV environment variable works fine when testing hof-bootstrap itself, but causes unexpected behaviour when testing apps which are dependent on hof-bootstrap.

Instead make the project root explicitly configurable, with a default of the current working directory.

Add a convenience method to the exported bootstrap module to allow for modifying global configuration. This allows for the default project root to be set in the integration tests without needing to be set in the constructor in each instantiation.

*Might* be a breaking change - `caller` config point isn't documented, so probably isn't used anywhere. Certainly isn't in any of our current workstreams.