### PR TITLE
Allow CSP to be disabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,24 +46,26 @@ const applyErrorMiddlewares = (app, config, i18n) => {
 
 function bootstrap(options) {
 
+  let config = getConfig(options);
+
   const app = express();
   const userMiddleware = express.Router();
 
   app.use(helmet());
 
-  /* eslint-disable quotes */
-  app.use(helmet.contentSecurityPolicy({
-    directives: {
-      defaultSrc: ["'none'"],
-      styleSrc: ["'self'"],
-      imgSrc: ["'self'"],
-      fontSrc: ["'self'", "data:"],
-      scriptSrc: ["'self'", "'unsafe-inline'"]
-    }
-  }));
-  /* eslint-enable quotes */
-
-  let config = getConfig(options);
+  if (config.csp) {
+    /* eslint-disable quotes */
+    app.use(helmet.contentSecurityPolicy({
+      directives: {
+        defaultSrc: ["'none'"],
+        styleSrc: ["'self'"],
+        imgSrc: ["'self'"],
+        fontSrc: ["'self'", "data:"],
+        scriptSrc: ["'self'", "'unsafe-inline'"]
+      }
+    }));
+    /* eslint-enable quotes */
+  }
 
   const i18n = i18nFuture({
     path: path.resolve(config.root, config.translations) + '/__lng__/__ns__.json'

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -5,6 +5,7 @@ const defaults = {
   root: process.cwd(),
   translations: 'translations',
   start: true,
+  csp: process.env.DISABLE_CSP !== 'true',
   getCookies: true,
   getTerms: true,
   viewEngine: 'html',


### PR DESCRIPTION
CSP prevents inline script injection, but running an automated browser for acceptance tests requires script injection. Allow CSP to be disabled so that we can run acceptance tests against apps.