### PR TITLE
Allow Content Security Policy directives to be extended with config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ constructor(options) {
 }
 ...
 ```
+- `csp` (We use [Helmetjs/csp](https://github.com/helmetjs/csp) middleware)
+  - `true` by default, enables Content Security Policy middleware.
+  - `false` set with custom config or with `process.env.DISABLE_CSP`, disables Content Security Policy middleware.
+  - CSP formatted object enables Content Security Policy middleware and extends default CSP directives with your own.
 
 - `viewEngine`: Name of the express viewEngine. Defaults to 'html'.
 - `start`: Start the server listening when the bootstrap function is called. Defaults to `true`.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "hof-template-partials": "^3.1.0",
     "hogan-express-strict": "^0.5.4",
     "i18n-future": "^1.0.0",
+    "lodash": "^4.17.4",
     "redis": "^2.6.0-2",
     "winston": "^1.1.2"
   },


### PR DESCRIPTION
The default directives can be extended when required rather than adding more defaults to core that would likely be implementation oriented. Such as adding www.google.com... as a an allowed src for the analytics code