### PR TITLE
Add google as a source to directives for imag and script when `gaTagI…

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,16 +45,27 @@ const applyErrorMiddlewares = (app, config, i18n) => {
   }));
 };
 
-const getContentSecurityPolicy = (csp) => {
+const getContentSecurityPolicy = config => {
+  let csp = config.csp;
   let directives = {
     /* eslint-disable quotes */
     defaultSrc: ["'none'"],
     styleSrc: ["'self'"],
     imgSrc: ["'self'"],
-    fontSrc: ["'self'", "data:"],
+    fontSrc: ["'self'", 'data:'],
     scriptSrc: ["'self'", "'unsafe-inline'"]
     /* eslint-enable quotes */
   };
+
+  let gaDirectives = {
+    scriptSrc: 'http://www.google-analytics.com/analytics.js',
+    imgSrc: 'http://www.google-analytics.com/collect'
+  };
+
+  if (config.gaTagId) {
+    directives.scriptSrc = directives.scriptSrc.concat(gaDirectives.scriptSrc);
+    directives.imgSrc = directives.imgSrc.concat(gaDirectives.imgSrc);
+  }
 
   if (_.isPlainObject(csp)) {
     _.each(csp, (value, name) => {
@@ -80,7 +91,7 @@ function bootstrap(options) {
 
   if (config.csp) {
     app.use(helmet.contentSecurityPolicy({
-      directives: getContentSecurityPolicy(config.csp)
+      directives: getContentSecurityPolicy(config)
     }));
   }
 


### PR DESCRIPTION
…d` is set

When `gaTagId` is set then the google analytics script is included in the  view template, which in turn loads it's own script and image from google. This change also adds google.... to the CSP directives meaning those scripts can be loaded and google analytics will work.

shizzle to @lennym for the suggestion