### PR TITLE
Make GA CSP directive urls broader to allow google to include js and images

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ constructor(options) {
   - `true` by default, enables Content Security Policy middleware.
   - `false` set with custom config or with `process.env.DISABLE_CSP`, disables Content Security Policy middleware.
   - CSP formatted object enables Content Security Policy middleware and extends default CSP directives with your own.
+  - If `gaTagId` is set, the CSP directives are auto-amended to include www.google-analytics.com as a source for js and images.
 
 - `viewEngine`: Name of the express viewEngine. Defaults to 'html'.
 - `start`: Start the server listening when the bootstrap function is called. Defaults to `true`.

--- a/index.js
+++ b/index.js
@@ -58,8 +58,8 @@ const getContentSecurityPolicy = config => {
   };
 
   let gaDirectives = {
-    scriptSrc: 'http://www.google-analytics.com/analytics.js',
-    imgSrc: 'http://www.google-analytics.com/collect'
+    scriptSrc: 'www.google-analytics.com',
+    imgSrc: 'www.google-analytics.com'
   };
 
   if (config.gaTagId) {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -541,8 +541,8 @@ describe('bootstrap()', () => {
         .set('Cookie', ['myCookie=1234'])
         .expect((res) => {
           const csp = getHeaders(res, 'content-security-policy');
-          csp['img-src'].should.include('http://www.google-analytics.com/collect');
-          csp['script-src'].should.include('http://www.google-analytics.com/analytics.js');
+          csp['img-src'].should.include('www.google-analytics.com');
+          csp['script-src'].should.include('www.google-analytics.com');
         });
     });
 
@@ -566,8 +566,14 @@ describe('bootstrap()', () => {
         .set('Cookie', ['myCookie=1234'])
         .expect((res) => {
           const csp = getHeaders(res, 'content-security-policy');
-          csp['img-src'].should.include('http://www.google-analytics.com/collect', 'bar', 'self', 'data:');
-          csp['script-src'].should.include('http://www.google-analytics.com/analytics.js', 'poo', 'self');
+          /* eslint-disable quotes */
+          csp['img-src'].should.include('www.google-analytics.com')
+            .and.include('bar')
+            .and.include("'self'");
+          csp['script-src'].should.include('www.google-analytics.com')
+            .and.include('foo')
+            .and.include("'self'");
+          /* eslint-enable quotes */
         });
     });
 


### PR DESCRIPTION
Discovered in the real world that google analytics script loads image from unexpected path.
By allowing google to load scripts and images we remove the overhead of regularly updating bootstrap or defining custom csp at implementation, so...

- remove protocol from google url
- remove path from google url
- include note in docs


