### PR TITLE
Allow apps to not have their own views directory

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -23,12 +23,16 @@ module.exports = class Helpers {
     };
   }
 
-  static getViews(views) {
+  static getViews(views, strict) {
     if (views) {
       try {
         fs.accessSync(views);
       } catch (err) {
-        throw new Error(`Cannot find route views at ${views}`);
+        if (strict) {
+          throw new Error(`Cannot find route views at ${views}`);
+        } else {
+          return null;
+        }
       }
     }
     return views;

--- a/lib/router.js
+++ b/lib/router.js
@@ -26,7 +26,7 @@ module.exports = config => {
   const i18n = i18nFuture({
     path: paths.translations + '/__lng__/__ns__.json'
   });
-  const routeViews = helpers.getViews(paths.views);
+  const routeViews = helpers.getViews(paths.views, config.route.views);
   const sharedViews = config.sharedViews;
 
   const views = routeViews ? [routeViews].concat(sharedViews) : sharedViews;

--- a/test/fixtures/apps/app_3/fields.js
+++ b/test/fixtures/apps/app_3/fields.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = {};

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -118,6 +118,16 @@ describe('bootstrap()', () => {
     })).should.Throw(`Cannot find route views at ${root}/invalid_path`)
   );
 
+  it('does not throw if no route views option is specified and the default route views directory does not exist', () =>
+    (() => bootstrap({
+      fields: 'fields',
+      routes: [{
+        name: 'app_3',
+        steps: {}
+      }]
+    })).should.not.Throw()
+  );
+
   describe('with valid routes and steps', () => {
 
     it('returns the bootstrap interface object', () =>


### PR DESCRIPTION
If an app is only using common views, or views have been mounted elsewhere, then there is no need for an app to have it's own views directory. Allow apps which are created with no specified views directory to not throw if the views directory is the default and doesn't exist.