### PR TITLE
Merge config instead of assigning

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const customConfig = {};
 
 const getConfig = function getConfig() {
   const args = [].slice.call(arguments);
-  return Object.assign.apply(null, [{}, defaults, customConfig].concat(args));
+  return _.merge.apply(_, [{}, defaults, customConfig].concat(args));
 };
 
 const loadRoutes = (app, config) => {


### PR DESCRIPTION
This allows apps to set only parts of config objects (session, redis) without having to set the entire object.