### PR TITLE
Add theme loader to bootstrap

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+/* eslint implicit-dependencies/no-implicit: [2, {optional:true}] */
 'use strict';
 
 const express = require('express');
@@ -22,7 +23,15 @@ const customConfig = {};
 
 const getConfig = function getConfig() {
   const args = [].slice.call(arguments);
-  return _.merge.apply(_, [{}, defaults, customConfig].concat(args));
+  const config = _.merge.apply(_, [{}, defaults, customConfig].concat(args));
+
+  if (!config.theme) {
+    config.theme = require('hof-theme-govuk');
+  } else if (typeof config.theme === 'string') {
+    config.theme = require(`hof-theme-${config.theme}`);
+  }
+
+  return config;
 };
 
 const loadRoutes = (app, config) => {
@@ -122,7 +131,7 @@ function bootstrap(options) {
   sessionStore(app, config);
 
   app.use(translate({
-    resources: require('hof-template-partials').resources(),
+    resources: config.theme.translations,
     path: path.resolve(config.root, config.translations) + '/__lng__/__ns__.json'
   }));
   app.use(mixins());

--- a/lib/router.js
+++ b/lib/router.js
@@ -34,7 +34,7 @@ module.exports = config => {
   app.use(expressPartialTemplates(app));
 
   app.use(translate({
-    resources: require('hof-template-partials').resources(),
+    resources: config.theme.translations,
     path: paths.translations + '/__lng__/__ns__.json'
   }));
   app.use(deepTranslate());

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -2,11 +2,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const template = require('hof-govuk-template');
 const hoganExpressStrict = require('hogan-express-strict');
 const expressPartialTemplates = require('express-partial-templates');
 const bodyParser = require('body-parser');
-const views = require('hof-template-partials').views;
 
 module.exports = (app, config) => {
 
@@ -18,9 +16,9 @@ module.exports = (app, config) => {
     next();
   });
 
-  template.setup(app);
+  app.use(config.theme());
 
-  let viewPaths = [views];
+  let viewPaths = [].concat(config.theme.views);
   app.set('view engine', viewEngine);
   app.enable('view cache');
 

--- a/package.json
+++ b/package.json
@@ -39,11 +39,9 @@
     "express-session": "^1.13.0",
     "helmet": "^2.3.0",
     "hof-form-wizard": "^3.1.0",
-    "hof-govuk-template": "^1.0.0",
     "hof-middleware": "^1.1.0",
     "hof-middleware-markdown": "^1.0.0",
     "hof-template-mixins": "^4.0.0",
-    "hof-template-partials": "^3.4.0",
     "hogan-express-strict": "^0.5.4",
     "i18n-future": "^1.0.0",
     "lodash": "^4.17.4",
@@ -66,6 +64,9 @@
     "supertest": "^1.2.0",
     "supertest-as-promised": "^3.2.0",
     "travis-conditions": "0.0.0"
+  },
+  "optionalDependencies": {
+    "hof-theme-govuk": "^2.0.0"
   },
   "pre-commit": [
     "test"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "travis-conditions": "0.0.0"
   },
   "optionalDependencies": {
-    "hof-theme-govuk": "^2.0.0"
+    "hof-theme-govuk": ">=2"
   },
   "pre-commit": [
     "test"


### PR DESCRIPTION
Allows theme to either be passed as a module or as a string suffix.

If the theme is provided as a string then it is resolved to `hof-theme-${theme}` and then required.

Themes should export a middleware function as default and have `translations` and `views` properties which define:

* `translations` a full mapping of languages and namespaces for translation content
* `views` a path, or array of paths, to the themes template files

See [hof-theme-govuk](http://npmjs/hof-theme-govuk) or [hof-theme-whitelabel](http://npmjs/hof-theme-whitelabel) for example

Probably don't merge this until we have a consensus on what a theme should look like to avoid having a stream of major version bumps.