### PR TITLE
Pass entire redis config to `createClient`

### DIFF
--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -30,7 +30,7 @@ module.exports = (app, config) => {
 
   const encryption = require('./encryption')(config.session.secret);
   const RedisStore = connectRedis(session);
-  const client = redis.createClient(config.redis.port, config.redis.host);
+  const client = redis.createClient(config.redis);
 
   if (config.env !== 'test') {
     client.on('connecting', function redisConnecting() {


### PR DESCRIPTION
This allows redis auth settings to be set to optionally extend the default config and be passed into the redis client constructor if needed.