### PR TITLE
Prepare for v12/rename to `hof`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2017-04-21, Version 12.0.0 (Stable), @lennym
+* Renames to `hof`!
+* Includes refactor of `hof-form-controller` to move error messaging to a render-time concern.
+* Depecrates `Controller#Error` in favour of `Controller#ValidationError`
+
 ## 2017-04-21, Version 11.0.0 (Stable), @lennym
 * Adds themes. Ships with `hof-theme-govuk` as default.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ HOF (Home Office Forms) is a framework designed to assist developers in creating
 ### Built with HOF
  * https://github.com/UKHomeOffice/gro
  * https://github.com/UKHomeOffice/end-tenancy
+ * [Firearms Licensing (Home Office)](https://github.com/UKHomeOffice/firearms)
  * [Contact UK Trade & Investment (UK Trade & Investment)](https://github.com/UKTradeInvestment/contact-ukti)
  * [Biometric Residence Permit (Home Office)](https://github.com/UKHomeOffice/brp_app)
  * [Report terrorist material (Home Office)](https://github.com/UKHomeOffice/rotm)

--- a/README.md
+++ b/README.md
@@ -1,22 +1,17 @@
-# HOF (Home Office Forms) Bootstrap [![Build Status](https://travis-ci.org/UKHomeOfficeForms/hof-bootstrap.svg?branch=master)](https://travis-ci.org/UKHomeOfficeForms/hof-bootstrap) [![npm version](https://badge.fury.io/js/hof-bootstrap.svg)](https://badge.fury.io/js/hof-bootstrap) [![Known Vulnerabilities](https://snyk.io/test/npm/hof-bootstrap/badge.svg)](https://snyk.io/test/npm/hof-bootstrap)
+# HOF (Home Office Forms) [![Build Status](https://travis-ci.org/UKHomeOfficeForms/hof-bootstrap.svg?branch=master)](https://travis-ci.org/UKHomeOfficeForms/hof-bootstrap) [![npm version](https://badge.fury.io/js/hof.svg)](https://badge.fury.io/js/hof) [![Known Vulnerabilities](https://snyk.io/test/npm/hof/badge.svg)](https://snyk.io/test/npm/hof)
 
-
-HOF-bootstrap is a wrapper function for HOF. It takes the hard work out of setting up your HOF service by encapsulating much of the boilerplate code in a single function. The bootstrap function takes many custom settings and options, but essentially maps your steps to Express routes and (optionally) starts the Express server.
-
-- [Getting started](./docs/getting-started.md)
-- [Bootstrap Interface](./docs/interface.md)
-- [Base configuration](./docs/configuration.md)
-- [Routes, steps, fields](./docs/routes.md)
-- [Resources](#resources)
-- [Example form](./example)
+HOF (Home Office Forms) is a framework designed to assist developers in creating form-based workflows in a rapid, repeatable and secure way. It aims to reduce simple applications as much as possible to being configuration-only.
 
 ## Resources
 
 ### HOF documentation
-https://github.com/UKHomeOfficeForms/HOF/blob/master/documentation/index.md
 
-### Built with HOF-bootstrap
-- https://github.com/UKHomeOffice/gro
-- https://github.com/UKHomeOffice/rotm
-- https://github.com/UKHomeOffice/end-tenancy
-- https://github.com/UKHomeOffice/UKVI-Complaints
+[https://ukhomeofficeforms.github.io/hof-guide/](https://ukhomeofficeforms.github.io/hof-guide/)
+
+### Built with HOF
+ * https://github.com/UKHomeOffice/gro
+ * https://github.com/UKHomeOffice/end-tenancy
+ * [Contact UK Trade & Investment (UK Trade & Investment)](https://github.com/UKTradeInvestment/contact-ukti)
+ * [Biometric Residence Permit (Home Office)](https://github.com/UKHomeOffice/brp_app)
+ * [Report terrorist material (Home Office)](https://github.com/UKHomeOffice/rotm)
+ * [UKVI Complaints (Home Office)](https://github.com/UKHomeOffice/Complaints)

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 /* eslint implicit-dependencies/no-implicit: [2, {optional:true}] */
 'use strict';
 
-require('deprecate')('`hof-bootstrap` will be renamed to `hof` from version 12.');
-
 const express = require('express');
 const churchill = require('churchill');
 const path = require('path');

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hof-bootstrap",
+  "name": "hof",
   "description": "A bootstrap for HOF projects",
   "version": "11.2.2",
   "license": "MIT",
@@ -38,7 +38,7 @@
     "express-partial-templates": "^0.2.0",
     "express-session": "^1.13.0",
     "helmet": "^2.3.0",
-    "hof-form-wizard": "^3.1.0",
+    "hof-form-wizard": "^4.0.0",
     "hof-middleware": "^1.1.0",
     "hof-middleware-markdown": "^1.0.0",
     "hof-template-mixins": "^4.0.0",


### PR DESCRIPTION
### Changes

* Renamed
* Updated README
  * Merged list of "Projects using hof" with the one from old hof repo
  * Updated badges that look like they're referencing the npm name
  * Updated description to make it sound like "the thing" and not just a wrapper
* Updated `hof-form-wizard` to latest